### PR TITLE
Moving entities After or Before an entity on another Group

### DIFF
--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -93,11 +93,10 @@ trait SortableTrait
             $oldPosition = $this->getAttribute($sortableField);
             $newPosition = $entity->getAttribute($sortableField);
 
-            if($groupField && $this->getCanSwitchBetweenGroups()) {
+            if ($groupField && $this->getCanSwitchBetweenGroups()) {
                 $oldList = $this->getAttribute($groupField);
                 $newList = $entity->getAttribute($groupField);
-                if($oldList !== $newList)
-                {
+                if ($oldList !== $newList) {
                     $query = static::applySortableGroup(static::on(), $entity);
                     $oldPosition = $query->max($sortableField) + 1;
                     $this->setAttribute($groupField,$newList);
@@ -270,8 +269,9 @@ trait SortableTrait
     {
         $sortableGroupField = self::getSortableGroupField();
 
-        if($sortableGroupField == null || is_array($sortableGroupField))
+        if ($sortableGroupField == null || is_array($sortableGroupField)) {
             return false;
+        }
 
         return isset(static::$switchBetweenGroups) ? static::$switchBetweenGroups : false;
     }
@@ -294,7 +294,7 @@ trait SortableTrait
      */
     public function checkSortableGroupField($sortableGroupField, $entity)
     {
-        if($this->getCanSwitchBetweenGroups()) {
+        if ($this->getCanSwitchBetweenGroups()) {
             return;
         }
 

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -99,7 +99,7 @@ trait SortableTrait
                 if ($oldList !== $newList) {
                     $query = static::applySortableGroup(static::on(), $entity);
                     $oldPosition = $query->max($sortableField) + 1;
-                    $this->setAttribute($groupField,$newList);
+                    $this->setAttribute($groupField, $newList);
                 }
             }
 

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -100,6 +100,7 @@ trait SortableTrait
                 {
                     $query = static::applySortableGroup(static::on(), $entity);
                     $oldPosition = $query->max($sortableField) + 1;
+                    $this->setAttribute($groupField,$newList);
                 }
             }
 

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -93,7 +93,7 @@ trait SortableTrait
             $oldPosition = $this->getAttribute($sortableField);
             $newPosition = $entity->getAttribute($sortableField);
 
-            if($groupField) {
+            if($groupField && $this->getCanSwitchBetweenGroups()) {
                 $oldList = $this->getAttribute($groupField);
                 $newList = $entity->getAttribute($groupField);
                 if($oldList !== $newList)
@@ -264,6 +264,14 @@ trait SortableTrait
     }
 
     /**
+     * @return bool
+     */
+    public static function getCanSwitchBetweenGroups()
+    {
+        return isset(static::$switchBetweenGroups) ? static::$switchBetweenGroups : false;
+    }
+
+    /**
      * @return string
      */
     public static function getSortableField()
@@ -281,7 +289,7 @@ trait SortableTrait
      */
     public function checkSortableGroupField($sortableGroupField, $entity)
     {
-        if(static::$switchBetweenGroups) {
+        if($this->getCanSwitchBetweenGroups()) {
             return;
         }
 

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -268,6 +268,11 @@ trait SortableTrait
      */
     public static function getCanSwitchBetweenGroups()
     {
+        $sortableGroupField = self::getSortableGroupField();
+
+        if($sortableGroupField == null || is_array($sortableGroupField))
+            return false;
+
         return isset(static::$switchBetweenGroups) ? static::$switchBetweenGroups : false;
     }
 

--- a/tests/SortableGroupTraitTest.php
+++ b/tests/SortableGroupTraitTest.php
@@ -133,7 +133,7 @@ class SortableGroupTraitTest extends SortableTestBase
         $entities = [];
         for ($i = 1; $i <= $count; ++$i) {
             $entities[$i] = new SortableEntityGroupWithMoveBetweenGroups();
-            $entities[$i]->category = $i%2;
+            $entities[$i]->category = $i % 2;
             $entities[$i]->save();
         }
 

--- a/tests/SortableGroupTraitTest.php
+++ b/tests/SortableGroupTraitTest.php
@@ -363,7 +363,6 @@ class SortableGroupTraitTest extends SortableTestBase
         $this->assertEquals($actualPos + 1, $entity->position);
     }
 
-
     /**
      * @return array
      */

--- a/tests/stubs/SortableGroupEntity.php
+++ b/tests/stubs/SortableGroupEntity.php
@@ -7,4 +7,5 @@ class SortableEntityGroup extends \Illuminate\Database\Eloquent\Model
     protected $table = 'sortable_entities_group';
 
     protected static $sortableGroupField = 'category';
+    protected static $switchBetweenGroups = false;
 }

--- a/tests/stubs/SortableGroupEntityWithMoveBetweenGroups.php
+++ b/tests/stubs/SortableGroupEntityWithMoveBetweenGroups.php
@@ -1,0 +1,6 @@
+<?php
+
+class SortableEntityGroupWithMoveBetweenGroups extends SortableEntityGroup
+{
+    protected static $switchBetweenGroups = true;
+}


### PR DESCRIPTION
Hi, nice package. I needed to move Items that are Grouped in different lists so I extended the code to be able to do so with the regular moveBefore or moveAfter, just by overriding $switchBetweenGroups and setting it to true. Added a few tests also based on the ones you had for groups. 
Important: I only did it for the case of grouping by one column. For multiple columns it will still behave as if $switchBetweenGroups = false. 