### PR TITLE
Support sortable entities with non-default database connection

### DIFF
--- a/src/Rutorika/Sortable/SortableController.php
+++ b/src/Rutorika/Sortable/SortableController.php
@@ -71,8 +71,13 @@ class SortableController extends Controller
             return $validator->make($request->all(), $rules);
         }
 
+        $connectionName = with(new $entityClass())->getConnectionName();
         $tableName = with(new $entityClass())->getTable();
         $primaryKey = with(new $entityClass())->getKeyName();
+
+        if (!empty($connectionName)) {
+            $tableName = $connectionName . '.' . $tableName;
+        }
 
         if (!$relation) {
             $rules['id'] .= '|exists:' . $tableName . ',' . $primaryKey;

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -29,7 +29,7 @@ trait SortableTrait
             function ($model) {
                 /* @var Model $model */
                 $sortableField = static::getSortableField();
-                $query = static::applySortableGroup(static::on(), $model);
+                $query = static::applySortableGroup(static::on($model->getConnectionName()), $model);
 
                 // only automatically calculate next position with max+1 when a position has not been set already
                 if ($model->$sortableField === null) {

--- a/tests/SortableControllerSpecificDatabaseTest.php
+++ b/tests/SortableControllerSpecificDatabaseTest.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once 'stubs/SortableEntity.php';
+require_once 'stubs/SortableEntityWithSpecificDatabase.php';
 require_once 'stubs/M2mEntity.php';
 require_once 'stubs/M2mRelatedEntity.php';
 
-class SortableControllerTest extends Orchestra\Testbench\TestCase
+class SortableControllerSpecificDatabaseTest extends Orchestra\Testbench\TestCase
 {
     public function setUp()
     {
@@ -15,7 +15,7 @@ class SortableControllerTest extends Orchestra\Testbench\TestCase
         ]);
 
         for ($i = 1; $i <= 30; ++$i) {
-            $entities[$i] = new SortableEntity();
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
             $entities[$i]->save();
         }
 
@@ -64,8 +64,8 @@ class SortableControllerTest extends Orchestra\Testbench\TestCase
         $app['config']->set(
             'sortable.entities',
             [
-                'sortable_entity' => '\SortableEntity',
-                'sortable_entity_full_config' => ['entity' => '\SortableEntity'],
+                'sortable_entity' => '\SortableEntityWithSpecificDatabase',
+                'sortable_entity_full_config' => ['entity' => '\SortableEntityWithSpecificDatabase'],
                 'sortable_entity_m2m' => ['entity' => '\M2mEntity', 'relation' => 'relatedEntities'],
                 'sortable_entity_without_class' => '\SortableEntityNotExist',
 

--- a/tests/SortableTestBase.php
+++ b/tests/SortableTestBase.php
@@ -25,6 +25,14 @@ class SortableTestBase extends Orchestra\Testbench\TestCase
                 'prefix' => '',
             ]
         );
+        $app['config']->set(
+            'database.connections.other',
+            [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ]
+        );
     }
 
     protected function getPackageProviders($app)

--- a/tests/SortableTraitWithSpecificDatabaseTest.php
+++ b/tests/SortableTraitWithSpecificDatabaseTest.php
@@ -1,0 +1,478 @@
+<?php
+
+require_once 'stubs/SortableEntityWithSpecificDatabase.php';
+require_once 'SortableTestBase.php';
+
+class SortableTraitWithSpecificDatabaseTest extends SortableTestBase
+{
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        // fix for "Eloquent model events are not triggered when testing" https://github.com/laravel/framework/issues/1181
+        SortableEntityWithSpecificDatabase::boot();
+    }
+
+    public function testPositionOnCreate()
+    {
+        $entity = new SortableEntityWithSpecificDatabase();
+        $entity->save();
+        $this->assertEquals(1, $entity->position);
+
+        $entity2 = new SortableEntityWithSpecificDatabase();
+        $entity2->save();
+        $this->assertEquals(2, $entity2->position);
+    }
+
+    public function testPosition()
+    {
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+            $this->assertEquals($i, $entities[$i]->id);
+            $this->assertEquals($i, $entities[$i]->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityComesBeforeRelativeEntityProvider
+     */
+    public function testMoveAfterWhenMovedEntityComesBeforeRelativeEntity($entityId, $relativeEntityId, $countTotal)
+    {
+
+        // interavls: [1 .. $entityId - 1], [$entityId], [$entityId + 1 .. $relativeEntityId], [$relativeEntityId .. $countTotal]
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $relyEntity = $entities[$relativeEntityId];
+
+        $moveEntity->moveAfter($relyEntity);
+
+        $this->assertEquals($relativeEntityId, $moveEntity->position);
+        $this->assertEquals($relativeEntityId - 1, $relyEntity->position);
+
+        // check [1 .. $entityId - 1] entities
+        for ($id = 1; $id < $entityId; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+
+        // check $entityId entity
+        $entity = SortableEntityWithSpecificDatabase::find($entityId);
+        $this->assertEquals($relativeEntityId, $entity->position);
+
+        // check  [$entityId + 1 .. $relativeEntityId] entities
+        for ($id = $entityId + 1; $id <= $relativeEntityId; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id - 1, $entity->position);
+        }
+
+        // check  [$relativeEntityId + 1 .. $countTotal] entities
+        for ($id = $relativeEntityId + 1; $id <= $countTotal; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityComesAfterRelativeEntityProvider
+     */
+    public function testMoveAfterWhenMovedEntityComesAfterRelativeEntity($entityId, $relativeEntityId, $countTotal)
+    {
+        // interavls: [1 .. $relativeEntityId], , [$relativeEntityId + 1 .. $entityId - 1], [$entityId], [$entityId + 1 .. $countTotal]
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $relyEntity = $entities[$relativeEntityId];
+
+        $moveEntity->moveAfter($relyEntity);
+        $this->assertEquals($relativeEntityId + 1, $moveEntity->position);
+
+        // check [1 .. $relativeEntityId] entities
+        for ($id = 1; $id <= $relativeEntityId; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+
+        // check  [$relativeEntityId + 1 .. $entityId - 1] entities
+        for ($id = $relativeEntityId + 1; $id <= $entityId - 1; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id + 1, $entity->position);
+        }
+
+        // check $entityId entity
+        $entity = SortableEntityWithSpecificDatabase::find($entityId);
+        $this->assertEquals($relativeEntityId + 1, $entity->position);
+
+        // check  [$entityId + 1 .. $countTotal] entities
+        for ($id = $entityId + 1; $id <= $countTotal; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityIsRelativeEntityProvider
+     */
+    public function testMoveAfterWhenMovedEntityIsRelativeEntity($entityId, $countTotal)
+    {
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $moveEntity->moveAfter($moveEntity);
+
+        $this->assertEquals($entityId, $moveEntity->position);
+
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $this->assertEquals($i, SortableEntityWithSpecificDatabase::find($i)->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityComesBeforeRelativeEntityProvider
+     */
+    public function testMoveBeforeWhenMovedEntityComesBeforeRelativeEntity($entityId, $relativeEntityId, $countTotal)
+    {
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $relyEntity = $entities[$relativeEntityId];
+
+        $moveEntity->moveBefore($relyEntity);
+        $this->assertEquals($relativeEntityId - 1, $moveEntity->position);
+
+        // check [1 .. $entityId - 1] entities
+        for ($id = 1; $id < $entityId; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+
+        // check $entityId entity
+        $entity = SortableEntityWithSpecificDatabase::find($entityId);
+        $this->assertEquals($relativeEntityId - 1, $entity->position);
+
+        // check  [$entityId + 1 .. $relativeEntityId] entities
+        for ($id = $entityId + 1; $id <= $relativeEntityId - 1; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id - 1, $entity->position);
+        }
+
+        // check  [$relativeEntityId + 1 .. $countTotal] entities
+        for ($id = $relativeEntityId; $id <= $countTotal; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityComesAfterRelativeEntityProvider
+     */
+    public function testMoveBeforeWhenMovedEntityComesAfterRelativeEntity($entityId, $relativeEntityId, $countTotal)
+    {
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $relyEntity = $entities[$relativeEntityId];
+
+        $moveEntity->moveBefore($relyEntity);
+        $this->assertEquals($relativeEntityId, $moveEntity->position);
+        $this->assertEquals($relativeEntityId + 1, $relyEntity->position);
+
+        // check [1 .. $relativeEntityId] entities
+        for ($id = 1; $id <= $relativeEntityId - 1; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+
+        // check  [$relativeEntityId + 1 .. $entityId - 1] entities
+        for ($id = $relativeEntityId; $id <= $entityId - 1; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id + 1, $entity->position);
+        }
+
+        // check $entityId entity
+        $entity = SortableEntityWithSpecificDatabase::find($entityId);
+        $this->assertEquals($relativeEntityId, $entity->position);
+
+        // check  [$entityId + 1 .. $countTotal] entities
+        for ($id = $entityId + 1; $id <= $countTotal; ++$id) {
+            $entity = SortableEntityWithSpecificDatabase::find($id);
+            $this->assertEquals($id, $entity->position);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @dataProvider moveWhenMovedEntityIsRelativeEntityProvider
+     */
+    public function testMoveBeforeWhenMovedEntityIsRelativeEntity($entityId, $countTotal)
+    {
+
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $moveEntity = $entities[$entityId];
+        $moveEntity->moveBefore($moveEntity);
+
+        $this->assertEquals($entityId, $moveEntity->position);
+
+        for ($i = 1; $i <= $countTotal; ++$i) {
+            $this->assertEquals($i, SortableEntityWithSpecificDatabase::find($i)->position);
+        }
+    }
+
+    public function testSortedScope()
+    {
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+
+        $entities[7]->moveAfter($entities[9]);
+        $entities[6]->moveAfter($entities[12]);
+        $entities[5]->moveBefore($entities[2]);
+
+        $sortedEntities = SortableEntityWithSpecificDatabase::sorted()->get();
+
+        $prevEntityPosition = null;
+
+        foreach ($sortedEntities as $sortedEntity) {
+            if ($prevEntityPosition !== null) {
+                $this->assertGreaterThan($prevEntityPosition, $sortedEntity->position);
+            }
+            $prevEntityPosition = $sortedEntity->position;
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider getPreviousNextEntityProvider
+     */
+    public function testGetPrevious($entityId, $limit)
+    {
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+        /** @var SortableEntity $entity */
+        $entity = $entities[$entityId];
+
+        $previous = $entity->getPrevious($limit);
+
+        $expectedCount = $limit ? min($limit, $entityId - 1) : $entityId - 1;
+        $this->assertEquals($expectedCount, $previous->count());
+
+        /** @var SortableEntity|null $curr */
+        $curr = null;
+
+        $startId = $entityId - $expectedCount;
+
+        foreach ($previous as $prev) {
+            $this->assertEquals($startId, $prev->id);
+            if ($curr) {
+                $this->assertEquals($curr->position + 1, $prev->position);
+            }
+            $curr = $prev;
+            ++$startId;
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider getPreviousNextEntityProvider
+     */
+    public function testGetNext($entityId, $limit)
+    {
+        /** @var SortableEntity[] $entities */
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+        /** @var SortableEntity $entity */
+        $entity = $entities[$entityId];
+
+        $next = $entity->getNext($limit);
+
+        $totalNext = count($entities) - $entityId;
+        $expectedCount = $limit ? min($totalNext, $limit) : $totalNext;
+        $this->assertEquals($expectedCount, $next->count());
+
+        /** @var SortableEntity|null $curr */
+        $curr = null;
+
+        $startId = $entityId + 1;
+
+        foreach ($next as $ent) {
+            $this->assertEquals($startId, $ent->id);
+            if ($curr) {
+                $this->assertEquals($curr->position + 1, $ent->position);
+            }
+            $curr = $ent;
+            ++$startId;
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider getPreviousNextEntityProvider
+     */
+    public function testDefaultsPrevious($entityId, $limit)
+    {
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+        /** @var SortableEntity $entity */
+        $entity = $entities[$entityId];
+
+        $expectedEntities = $entity->getPrevious(0);
+        $previous = $entity->getPrevious();
+        $this->assertEquals($expectedEntities->count(), $previous->count());
+        for ($i = 0; $i < $previous->count(); ++$i) {
+            $this->assertEquals($expectedEntities->offsetGet($i)->id, $previous->offsetGet($i)->id);
+        }
+    }
+
+    /**
+     * @param
+     * @param
+     * @param
+     * @dataProvider getPreviousNextEntityProvider
+     */
+    public function testDefaultsNext($entityId, $limit)
+    {
+        $entities = [];
+        for ($i = 1; $i <= 30; ++$i) {
+            $entities[$i] = new SortableEntityWithSpecificDatabase();
+            $entities[$i]->save();
+        }
+        /** @var SortableEntity $entity */
+        $entity = $entities[$entityId];
+
+        $expectedEntities = $entity->getNext(0);
+        $next = $entity->getNext();
+        $this->assertEquals($expectedEntities->count(), $next->count());
+        for ($i = 0; $i < $next->count(); ++$i) {
+            $this->assertEquals($expectedEntities->offsetGet($i)->id, $next->offsetGet($i)->id);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function moveWhenMovedEntityComesAfterRelativeEntityProvider()
+    {
+        return [
+            [7, 1, 30],
+            [9, 7, 30],
+            [30, 15, 30],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function moveWhenMovedEntityComesBeforeRelativeEntityProvider()
+    {
+        return [
+            [1, 7, 30],
+            [7, 9, 30],
+            [15, 30, 30],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function moveWhenMovedEntityIsRelativeEntityProvider()
+    {
+        return [
+            [1, 30],
+            [7, 30],
+            [30, 30],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getPreviousNextEntityProvider()
+    {
+        return [
+            [5, 0],
+            [5, 1],
+            [1, 1],
+            [10, 1],
+            [30, 1],
+            [5, 12],
+            [1, 10],
+            [10, 4],
+            [30, 4],
+        ];
+    }
+}

--- a/tests/SortableTraitWithSpecificDatabaseTest.php
+++ b/tests/SortableTraitWithSpecificDatabaseTest.php
@@ -5,7 +5,6 @@ require_once 'SortableTestBase.php';
 
 class SortableTraitWithSpecificDatabaseTest extends SortableTestBase
 {
-
     public function setUp()
     {
         parent::setUp();

--- a/tests/migrations/2017_08_25_184500_create_entities_with_specific_database_table.php
+++ b/tests/migrations/2017_08_25_184500_create_entities_with_specific_database_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateEntitiesWithSpecificDatabaseTable extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::connection('other')->create('sortable_entity_with_specific_databases', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('position')->default(1);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::connection('other')->table('sortable_entity_with_specific_databases', function (Blueprint $table) {
+            $table->drop();
+        });
+    }
+}

--- a/tests/stubs/SortableEntityWithSpecificDatabase.php
+++ b/tests/stubs/SortableEntityWithSpecificDatabase.php
@@ -1,0 +1,9 @@
+<?php
+
+class SortableEntityWithSpecificDatabase extends \Illuminate\Database\Eloquent\Model
+{
+    use Rutorika\Sortable\SortableTrait;
+
+    protected $connection = 'other';
+
+}

--- a/tests/stubs/SortableEntityWithSpecificDatabase.php
+++ b/tests/stubs/SortableEntityWithSpecificDatabase.php
@@ -5,5 +5,4 @@ class SortableEntityWithSpecificDatabase extends \Illuminate\Database\Eloquent\M
     use Rutorika\Sortable\SortableTrait;
 
     protected $connection = 'other';
-
 }


### PR DESCRIPTION
This pull-request fixes #43 and provides support for sortable entities using non-default database connection. Now the corresponding base table of the eloquent model can be found in the correct database.
In addition to the fix, I have written unit tests for a sortable entity using a specific database connection.