### PR TITLE
Reset model order on sortable group change

### DIFF
--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -317,7 +317,7 @@ trait SortableTrait
             return;
         }
 
-        if ($entity1->$field !== $entity2->$field) {
+        if ($entity1->$field != $entity2->$field) {
             throw new SortableException($entity1->$field, $entity2->$field);
         }
     }

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -35,16 +35,12 @@ trait SortableTrait
         static::saving(
             function ($model) {
                 /* @var Model $model */
-                if ($model->exists && $model->isDirty()) {
+                // Trusting isDirty(), not calling checkSortableGroupField to confirm
+                if ($model->exists && $model->isDirty(static::getSortableGroupField())) {
                     $sortableField = static::getSortableField();
-                    $plainOldModel = (object) $model->getOriginal();
 
-                    try {
-                        $model->checkSortableGroupField(static::getSortableGroupField(), $plainOldModel);
-                    } catch (SortableException $e) {
-                        // signal to reset order
-                        $model->$sortableField = null;
-                    }
+                    // signal to reset order
+                    $model->$sortableField = null;
                 }
 
                 self::_setOrder($model);

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -53,11 +53,12 @@ trait SortableTrait
     }
 
     /**
-     * Set model order if not set
+     * Set model order if not set.
      *
      * @param Model $model
      */
-    private static function _setOrder(Model $model) {
+    private static function _setOrder(Model $model)
+    {
         /* @var Model $model */
         $sortableField = static::getSortableField();
         $query = static::applySortableGroup(static::on($model->getConnectionName()), $model);

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -45,7 +45,7 @@ trait SortableTrait
 
                 if ($model->exists && $model->isDirty()) {
                     $old_model = $model->getOriginal();
-                    
+
                     try {
                         $model->checkSortableGroupField(static::getSortableGroupField(), $old_model);
                     } catch (SortableException $e) {

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -45,6 +45,7 @@ trait SortableTrait
 
                 if ($model->exists && $model->isDirty()) {
                     $old_model = $model->getOriginal();
+                    
                     try {
                         $model->checkSortableGroupField(static::getSortableGroupField(), $old_model);
                     } catch (SortableException $e) {

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -44,7 +44,7 @@ trait SortableTrait
                 $sortableField = static::getSortableField();
 
                 if ($model->exists && $model->isDirty()) {
-                    $old_model = new self($model->getDirty()); // or simple new object(array) would do?
+                    $old_model = $model->getOriginal();
                     try {
                         $model->checkSortableGroupField(static::getSortableGroupField(), $old_model);
                     } catch (SortableException $e) {

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -44,7 +44,7 @@ trait SortableTrait
                 $sortableField = static::getSortableField();
 
                 if ($model->exists && $model->isDirty()) {
-                    $old_model = $model->getOriginal();
+                    $old_model = new self($model->getOriginal());
 
                     try {
                         $model->checkSortableGroupField(static::getSortableGroupField(), $old_model);

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -44,10 +44,10 @@ trait SortableTrait
                 $sortableField = static::getSortableField();
 
                 if ($model->exists && $model->isDirty()) {
-                    $old_model = new self($model->getOriginal());
+                    $plainOldModel = (object) $model->getOriginal();
 
                     try {
-                        $model->checkSortableGroupField(static::getSortableGroupField(), $old_model);
+                        $model->checkSortableGroupField(static::getSortableGroupField(), $plainOldModel);
                     } catch (SortableException $e) {
                         // signal to reset order
                         $model->$sortableField = null;

--- a/src/Rutorika/Sortable/SortableTrait.php
+++ b/src/Rutorika/Sortable/SortableTrait.php
@@ -25,7 +25,6 @@ trait SortableTrait
      */
     public static function bootSortableTrait()
     {
-        
         static::creating(
             function ($model) {
                 /* @var Model $model */
@@ -63,7 +62,6 @@ trait SortableTrait
                 }
             }
         );
-
     }
 
     /**

--- a/tests/SortableControllerSpecificDatabaseTest.php
+++ b/tests/SortableControllerSpecificDatabaseTest.php
@@ -9,6 +9,7 @@ class SortableControllerSpecificDatabaseTest extends Orchestra\Testbench\TestCas
     public function setUp()
     {
         parent::setUp();
+        $this->withoutExceptionHandling();
         $this->loadMigrationsFrom([
             '--database' => 'testbench',
             '--realpath' => realpath(__DIR__ . '/migrations'),


### PR DESCRIPTION
When sortable group fields change, order value is unaffected. If the new sortable group already has ordered elements, order value duplication may occur, which in-turn breaks some [sorting operations](https://github.com/boxfrommars/rutorika-sortable/blob/master/src/Rutorika/Sortable/SortableTrait.php#L94).

This helps maintain order which may otherwise get messed up.