### PR TITLE
[BUG] Fix BelongsToSortedMany for Laravel 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=7",
+        "php": ">=7.1.3",
         "illuminate/support": ">=5.7"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7",
-        "illuminate/support": ">=5.5"
+        "illuminate/support": ">=5.7"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.3",

--- a/src/Rutorika/Sortable/BelongsToSortedManyTrait.php
+++ b/src/Rutorika/Sortable/BelongsToSortedManyTrait.php
@@ -50,7 +50,7 @@ trait BelongsToSortedManyTrait
         // models using underscores in alphabetical order. The two model names
         // are transformed to snake case from their default CamelCase also.
         if (is_null($table)) {
-            $table = $this->joiningTable($related);
+            $table = $this->joiningTable($related, $instance);
         }
 
         return new BelongsToSortedMany(
@@ -67,7 +67,7 @@ trait BelongsToSortedManyTrait
      *
      * @return string
      */
-    abstract public function joiningTable($related);
+    abstract public function joiningTable($related, $instance = null);
 
     /**
      * Get the default foreign key name for the model.


### PR DESCRIPTION
Laravel added an additional parameter to the `joiningTable` in 5.7 (https://laravel.com/api/5.7/Illuminate/Database/Eloquent/Concerns/HasRelationships.html#method_joiningTable)

This fixes that one issue.  Not sure if this makes everything good with 5.7, but it get's my project building again.